### PR TITLE
Feature/one of accept ref

### DIFF
--- a/test/ast/matches.spec.js
+++ b/test/ast/matches.spec.js
@@ -135,53 +135,24 @@ describe('ast - matches', () => {
     expect(matches(schema, [4])).toBe(false);
     expect(matches(schema, [5, 7])).toBe(true);
   });
+
+  it('should obey oneOf with a ref', () => {
+    const schema = {
+      schema: 'object',
+      shape: {
+        fieldB: {
+          tests: [['oneOf', ['a', 9, { ref: 'fieldA' }]]],
+        },
+        fieldC: {
+          tests: [['oneOf', { ref: 'fieldD' }]],
+        },
+      },
+    };
+
+    matches(schema, { fieldA: 'jim', fieldB: 'jim' }); // true
+    matches(schema, { fieldA: 'fred', fieldB: 'a' }); // true
+    matches(schema, { fieldB: 'jim' }); // false
+    matches(schema, { fieldC: 'jim', fieldD: ['joe', 'fred'] }); // false
+    matches(schema, { fieldC: 'joe', fieldD: ['joe', 'fred'] }); // true
+  });
 });
-
-/*
-
-```js
-{
-    schema: 'object' | 'array' | 'string' | 'mixed' | 'date' | 'boolean' | 'number',
-    default: 'some value',
-    label: 'some label',
-    tests:[
-        'required', // the name of a validator
-        ['max',10] // if an array, the first entry is the name of a validator and all others are passed as arguments to the validator
-        ['is',{ref:'$field'}] // works with refs
-        ['oneOf',['1','2',{ref:'$field.path'}]], // and nested refs
-    ],
-    conditions:[
-        when: [{
-            fieldA: {ast}
-            fieldB: {ast}
-        }],
-        when: ['fieldA','fieldB']
-        matches: [
-            [
-                {tests:['required']},
-                {tests:[['oneOf',['jim','joe','bill']]]}
-            ],
-            {
-                tests:['required']
-            }
-        ],
-        how:'some',
-        then: AST
-        otherwise: AST
-    ]
-
-    // when schema is 'array' it can accept "of"
-    of: {
-        schema: 'string',
-        tests: [...]
-    },
-
-    // when schema is 'object', it can accept "shape":
-    shape: {
-        fieldA: { schema: 'string' },
-        fieldB: { schema: 'mixed' },
-    }
-}
-```
-
-*/

--- a/test/validators/oneOf.spec.js
+++ b/test/validators/oneOf.spec.js
@@ -1,11 +1,15 @@
 import { oneOf, tests } from '../../src/validators';
-import { isValidSync, ref, mixed, object } from '../../src';
+import { isValidSync, validateSync, ref, mixed, object } from '../../src';
 import { def, label } from '../../src/utils';
 
 describe('validators - oneOf', () => {
   it('should validate', () => {
     expect(isValidSync(mixed(tests(oneOf([1, 2, 3]))), 1)).toBe(true);
     expect(isValidSync(mixed(tests(oneOf([1, 2, 3]))), 5)).toBe(false);
+  });
+
+  it('should pass when undefined', () => {
+    expect(isValidSync(mixed(tests(oneOf([1, 2, 3]))))).toBe(true);
   });
 
   it('should validate with a ref', () => {
@@ -16,6 +20,31 @@ describe('validators - oneOf', () => {
     expect(isValidSync(s, { field1: 'jim', a: 'jim' })).toBe(true);
     expect(isValidSync(s, { field1: 'jim', b: 'jim' })).toBe(true);
     expect(isValidSync(s, { field1: 'jim' })).toBe(false);
+  });
+
+  it('should validate with a ref that is an array', () => {
+    const schema = object({
+      field1: mixed(tests(oneOf(ref('$arr')))),
+    });
+
+    // should not fail if the ref can't be resolved
+    expect(isValidSync(schema, { field1: 'jim' })).toBe(true);
+
+    expect(
+      isValidSync(
+        schema,
+        { field1: 'jim' },
+        { context: { arr: ['jim', 2, 3] } }
+      )
+    ).toBe(true);
+
+    expect(
+      isValidSync(
+        schema,
+        { field1: 'jim' },
+        { context: { arr: ['fred', 2, 3] } }
+      )
+    ).toBe(false);
   });
 
   it('should validate with a relative ref', () => {

--- a/website/docs/validators.md
+++ b/website/docs/validators.md
@@ -20,7 +20,7 @@ All validators accept as their final argument the same set of options (optional)
 
 ### name
 
-By default, `name` is the `name` of the validator you are calling - i.e. the name for the `oneOf` validator is `oneOf`.
+By default, `name` is the `name` of the validator you are calling - i.e. the name for the [oneOf](#oneOf) validator is `oneOf`.
 
 ### params
 
@@ -53,6 +53,8 @@ getErrorsSync(schema,'jim'); // The value of first name should include fred
 ## Validators
 
 Validators aren't always applicable to all schemas ([min](#min) is not relevant for a [boolean schema](schemas.md#boolean), for instance) This is accomplished via a pre-validation hook which verifies that the current [ValidatorDefinition](#validatordefinition) is applicable to the current schema.
+
+**Note:** `undefined` is considered a valid value for all validators except [required](#required).
 
 ### required
 
@@ -168,14 +170,15 @@ isValidSync(schema, { fieldB: 'jim' }); // true
 </AstFn>
 
 
-
 ### oneOf
 
-**`oneOf(value: Array<any | Ref>, options: ValidatorOptions)`**
+**`oneOf(value: Ref | Array<any | Ref>, options: ValidatorOptions)`**
 
 Applicable to schemas: **ALL**
 
-Value being validated must be one of the values given to `oneOf`
+Value being validated must be one of the values given to `oneOf` OR if `value` is a [ref](typeref.md#astRef) then the value being validated must be one of the values in the reference.
+
+**Note:** Just a reminder that `undefined` is considered a valid value. If you need to test for `undefined` use [required](#required).
 
 <AstFn>
 
@@ -184,7 +187,10 @@ const schema = {
     schema:'object',
     shape: {
         fieldB: {
-            tests: [['oneOf', ['a', 9, { ref: 'fieldA' }]]
+            tests: [['oneOf', ['a', 9, { ref: 'fieldA' }]]]
+        },
+        fieldC: {
+            tests: [['oneOf', { ref: 'fieldD' }]]
         }
     }
 };
@@ -192,6 +198,8 @@ const schema = {
 matches(schema, { fieldA: 'jim', fieldB: 'jim'}); // true
 matches(schema, { fieldA: 'fred', fieldB: 'a'}); // true
 matches(schema, { fieldB: 'jim'}); // false
+matches(schema, { fieldC: 'jim', fieldD: ['joe','fred' ]}); // false
+matches(schema, { fieldC: 'joe', fieldD: ['joe','fred' ]}); // true
 ```
 
 ```js


### PR DESCRIPTION
- `oneOf` passes if the value being validated is undefined
- `oneOf` passes if the argument is an empty array
- `oneOf` can now accept a `ref` as an argument which may resolve to an array